### PR TITLE
Give user write permission to user nix.conf

### DIFF
--- a/modules/nix-access-tokens.nix
+++ b/modules/nix-access-tokens.nix
@@ -26,7 +26,7 @@ with lib;
           echo "setting up nix access-tokens for ${name}"
           mkdir -p ~/.config/nix
           echo "access-tokens = github.com=$(cat ${config.sops.secrets."${name}/github-token".path})" > ~/.config/nix/nix.conf
-          chmod 400 ~/.config/nix/nix.conf
+          chmod 600 ~/.config/nix/nix.conf
         '';
       };
     }) midgardUsers


### PR DESCRIPTION
The system.userActivation script for making user access-tokens was only working first time, when creating user config file. Changing token had to be done manually. This fixes that, and removes an error message when rebuilding.